### PR TITLE
concat directory separators instead of "/" to make it work on Windows…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export default function loader(content) {
 
   return `
 try {
-  process.dlopen(module, __dirname + "/" + __webpack_public_path__ + ${JSON.stringify(
+  process.dlopen(module, __dirname + require("path").sep + __webpack_public_path__ + ${JSON.stringify(
     name
   )}${
     typeof options.flags !== 'undefined'

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -5,7 +5,7 @@ exports[`loader should throw an error on broken "node" addon: errors 1`] = `Arra
 exports[`loader should throw an error on broken "node" addon: module 1`] = `
 "
 try {
-  process.dlopen(module, __dirname + \\"/\\" + __webpack_public_path__ + \\"broken.node\\");
+  process.dlopen(module, __dirname + require(\\"path\\").sep + __webpack_public_path__ + \\"broken.node\\");
 } catch (error) {
   throw new Error('node-loader:\\\\n' + error);
 }
@@ -19,7 +19,7 @@ exports[`loader should work: errors 1`] = `Array []`;
 exports[`loader should work: module 1`] = `
 "
 try {
-  process.dlopen(module, __dirname + \\"/\\" + __webpack_public_path__ + \\"hello.node\\", 1);
+  process.dlopen(module, __dirname + require(\\"path\\").sep + __webpack_public_path__ + \\"hello.node\\", 1);
 } catch (error) {
   throw new Error('node-loader:\\\\n' + error);
 }


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

bugfix for #39  https://github.com/webpack-contrib/node-loader/issues/39

### Motivation / Use-Case

Fix: windows platform dlopen path concat