### PR TITLE
Get example to work like node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Setup the `target` option to `node`/`async-node`/`electron-main`/`electron-rende
 
 ```js
 module.exports = {
+  resolve: {
+    extensions: ["...", ".node"],
+  },
   target: "node",
   node: {
     __dirname: false,


### PR DESCRIPTION
as a webpack newb it had caused me much confusion that `.node` extensions aren't registered by default.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case


ease life for newbs wanting to have webpack load `.node` extensions using the same precedence as node.js does