### PR TITLE
dlopen: relative path  =>  absolute path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,9 +23,9 @@ export default function loader(content) {
 
   return `
 try {
-  process.dlopen(module, __dirname + require("path").sep + __webpack_public_path__ + ${JSON.stringify(
+  process.dlopen(module, require("path").join(__dirname, __webpack_public_path__, ${JSON.stringify(
     name
-  )}${
+  )})${
     typeof options.flags !== "undefined"
       ? `, ${JSON.stringify(options.flags)}`
       : ""

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -5,7 +5,7 @@ exports[`loader should throw an error on broken "node" addon: errors 1`] = `Arra
 exports[`loader should throw an error on broken "node" addon: module 1`] = `
 "
 try {
-  process.dlopen(module, __dirname + require(\\"path\\").sep + __webpack_public_path__ + \\"broken.node\\");
+  process.dlopen(module, require(\\"path\\").join(__dirname, __webpack_public_path__, \\"broken.node\\"));
 } catch (error) {
   throw new Error('node-loader:\\\\n' + error);
 }
@@ -19,7 +19,7 @@ exports[`loader should work: errors 1`] = `Array []`;
 exports[`loader should work: module 1`] = `
 "
 try {
-  process.dlopen(module, __dirname + require(\\"path\\").sep + __webpack_public_path__ + \\"hello.node\\", 1);
+  process.dlopen(module, require(\\"path\\").join(__dirname, __webpack_public_path__, \\"hello.node\\"), 1);
 } catch (error) {
   throw new Error('node-loader:\\\\n' + error);
 }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When require a [.node] file within a [.asar] package, there is an unexpected issue with the Mac system. The error message states:
```
Error: dlopen(/Applications/xx.app/Contents/Resources/app/application.asar//../wrapper.node, 0x0001): 
tried: '/Applications/xx.app/Contents/Resources/app/application.asar//../wrapper.node' (errno=20), 
'/System/Volumes/Preboot/Cryptexes/OS/Applications/xx.app/Contents/Resources/app/application.asar//../wrapper.node' (no such file),
'/Applications/xx.app/Contents/Resources/app/application.asar//../wrapper.node'(errno=20)
```
However, it can be opened when using the absolute path:
`/Applications/xx.app/Contents/Resources/app/wrapper.node`
To resolve this, I've used `path.join` to format the path.

similar issue:  https://github.com/webpack-contrib/node-loader/issues/132
### Breaking Changes

no

### Additional Info
